### PR TITLE
AVS and CVD support

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ const format = (data, sanitize = true) => {
   const dataKey = fe(data.DataKey);
   const iso = fe(data.ISO);
   const receipt = fe(data.ReceiptId);
+  const avsResultCode = fe(data.AvsResultCode);
+  const cvdResultCode = fe(data.CvdResultCode);
   const isVisa = fe(data.CardType, 'V');
   const isMasterCard = fe(data.CardType, 'M');
   const isVisaDebit = fe(data.IsVisaDebit, 'true');
@@ -76,6 +78,12 @@ const format = (data, sanitize = true) => {
   }
   if (receipt && receipt !== 'null') {
     o.receipt = receipt;
+  }
+  if (avsResultCode) {
+    o.avsResultCode = avsResultCode;
+  }
+  if (cvdResultCode !== null && cvdResultCode !== 'null') {
+    o.cvdResultCode = cvdResultCode;
   }
   if (isVisa !== null && isVisa !== 'null') {
     o.isVisa = isVisa;
@@ -157,6 +165,12 @@ const send = async (data, type) => {
   if (out.token) {
     out.data_key = out.token;
     delete out.token;
+  }
+  if (out.cvd_info) {
+    out.cvd_info = out.cvd_info;
+  }
+  if (out.avs_info) {
+    out.avs_info = out.avs_info;
   }
   const body = {
     store_id: config.store_id,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -229,7 +229,18 @@ describe('Unit Testing', () => {
     });
     it('should receive an object with the following parameters', async () => {
       const purchasePayload = {
-        order_id: `OR-1${new Date()}`, amount: '0.08', pan: 4242424242424242, expdate: 2504, description: 'Nordik online reservation',
+        order_id: `OR-1${new Date()}`,
+        amount: '0.08', 
+        pan: 4242424242424242, 
+        expdate: 2504, 
+        cvd_info: { cvd_indicator: 1, cvd_value: 123 }, 
+        avs_info: { 
+          avs_street_number: '201',
+          avs_street_name: 'Michigan Ave',
+          avs_custphone: '5556667777',
+          avs_zipcode: 'M1M1M1'
+        }, 
+        description: 'Nordik online reservation',
       };
       const res = await moneris.purchase(purchasePayload);
       expect(res).to.be.a('object');


### PR DESCRIPTION
* Resolved previous conflicts 

For a more secure transaction during purchase, I have added optional support for AVS and CVD verification. Both verification are done by passing the objects inside the payload. The provided response values can be sent to Kount for better calculation with the risk ML model.

For required value : 
![Screen Shot 2021-02-09 at 4 12 45 PM](https://user-images.githubusercontent.com/32798524/107429175-a7371680-6af1-11eb-958e-8a9921d27cd1.png)