### PR TITLE
hotfix - properly evaluating test parameter of configuration since las update including default configs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,9 +229,14 @@ const send = async (data, type, configuration) => {
   }
   let hostPrefix = prefix;
   let filePrefix = prefix;
+
+  if (configuration.test !== undefined || configuration.test !== null) {
+    config.test = configuration.test;
+  }
   if (config.test) {
     hostPrefix += 'TEST_';
   }
+
   if (type === 'acs' || type === 'txn') {
     filePrefix += 'MPI_';
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moneryze",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Promise based wrapper for the Moneris API",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moneryze",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Promise based wrapper for the Moneris API",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moneryze",
-  "version": "1.0.10",
+  "version": "1.0.8",
   "description": "Promise based wrapper for the Moneris API",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moneryze",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "description": "Promise based wrapper for the Moneris API",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Following a recent deployment, I have found that the default configuration introduced in the last merge makes the evaluation of test property of the config object always true (which is default).

It seems that updates were done to allow configurations to be passed in the moneryze method directly instead of using the init function.

Unfortunately, even if configurations are passed as a parameter, the test property is still evaluated on config.test (default object) which is never overwritten.

Therefore, I have added a statement to evaluate if configuration.test is set and then it updates the value of config.test. Not sure it's the most elegant way, but considering that the value is a boolean I wanted to make a strict check.

A recent release candidate where moneryze.init were removed (on moneryze version 1.0.9) defaulted to Moneris' test environment if production configuration was passed.

**TLDR: config.test by default is set to true and is never overwritten in production environment if you don't use the moneryze.init method.**

